### PR TITLE
Don't create figures from images without caption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Render result:
 
 See [`figure_test.go`](/figure_test.go) for more examples.
 
+## Option to skip images without captions
+
+Example:
+
+```go
+goldmark.WithExtensions(
+    figure.Figure.WithSkipNoCaption(),
+),
+```
+
+In case a link to an image doesn't have a caption (a line of text following it without any linebreaks in between), it won't be warpped in a `<figure>`.
+
+See `TestFigureWithSkipNoCaption()` in [`figure_test.go`](/figure_test.go) for an example.
+
 # Changelog
 
 ## v1.2.0 (2024-06-19)

--- a/figure.go
+++ b/figure.go
@@ -17,6 +17,7 @@ import (
 
 type extension struct {
 	renderImageLink bool
+	skipNoCaption   bool
 }
 
 // Figure is an extension to render <figure> elements.
@@ -27,10 +28,15 @@ func (f *extension) WithImageLink() *extension {
 	return f
 }
 
+func (f *extension) WithSkipNoCaption() *extension {
+	f.skipNoCaption = true
+	return f
+}
+
 func (f *extension) Extend(m goldmark.Markdown) {
 	m.Parser().AddOptions(
 		aparser.WithParagraphTransformers(
-			util.Prioritized(fparser.NewFigureParagraphTransformer(), 120),
+			util.Prioritized(fparser.NewFigureParagraphTransformer(f.skipNoCaption), 120),
 		),
 		aparser.WithASTTransformers(
 			util.Prioritized(fparser.NewFigureASTTransformer(), 0),

--- a/figure_test.go
+++ b/figure_test.go
@@ -89,7 +89,7 @@ So this won't be a figure.</p>
 	count++
 	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
 		No:          count,
-		Description: "Image wihtout caption isn't a figure",
+		Description: "Image without caption isn't a figure",
 		Markdown: `
 Following image is without caption:
 

--- a/figure_test.go
+++ b/figure_test.go
@@ -89,6 +89,18 @@ So this won't be a figure.</p>
 	count++
 	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
 		No:          count,
+		Description: "Image wihtout caption isn't a figure",
+		Markdown: `
+![Alt text](https://example.com/image.jpg)
+`,
+		Expected: `
+<img src="https://example.com/image.jpg" alt="Alt text">
+`,
+	}, t)
+
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
 		Description: "Multiple paragraph content",
 		Markdown: `
 First paragraph.

--- a/figure_test.go
+++ b/figure_test.go
@@ -98,7 +98,7 @@ Following image is without caption:
 So this won't be a figure.
 `,
 		Expected: `<p>Following image is without caption:</p>
-<img src="https://example.com/image.jpg" alt="Alt text">
+<p><img src="https://example.com/image.jpg" alt="Alt text"></p>
 <p>So this won't be a figure.</p>
 `,
 	}, t)

--- a/figure_test.go
+++ b/figure_test.go
@@ -89,17 +89,19 @@ So this won't be a figure.</p>
 	count++
 	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
 		No:          count,
-		Description: "Image without caption isn't a figure",
+		Description: "Image without caption is still a figure",
 		Markdown: `
 Following image is without caption:
 
 ![Alt text](https://example.com/image.jpg)
 
-So this won't be a figure.
+But it'll still be a figure.
 `,
 		Expected: `<p>Following image is without caption:</p>
-<p><img src="https://example.com/image.jpg" alt="Alt text"></p>
-<p>So this won't be a figure.</p>
+<figure>
+<img src="https://example.com/image.jpg" alt="Alt text">
+</figure>
+<p>But it'll still be a figure.</p>
 `,
 	}, t)
 
@@ -207,6 +209,32 @@ Awesome captions about the **kitties**.
 </a>
 <figcaption><p>Awesome captions about the <strong>kitties</strong>.</p></figcaption>
 </figure>
+`,
+	}, t)
+}
+
+func TestFigureWithSkipNoCaption(t *testing.T) {
+	markdown := goldmark.New(
+		goldmark.WithExtensions(
+			figure.Figure.WithSkipNoCaption(),
+		),
+	)
+	count := 0
+
+	count++
+	testutil.DoTestCase(markdown, testutil.MarkdownTestCase{
+		No:          count,
+		Description: "Image without caption isn't a figure",
+		Markdown: `
+Following image is without caption:
+
+![Alt text](https://example.com/image.jpg)
+
+So this won't be a figure.
+`,
+		Expected: `<p>Following image is without caption:</p>
+<p><img src="https://example.com/image.jpg" alt="Alt text"></p>
+<p>So this won't be a figure.</p>
 `,
 	}, t)
 }

--- a/figure_test.go
+++ b/figure_test.go
@@ -91,10 +91,15 @@ So this won't be a figure.</p>
 		No:          count,
 		Description: "Image wihtout caption isn't a figure",
 		Markdown: `
+Following image is without caption:
+
 ![Alt text](https://example.com/image.jpg)
+
+So this won't be a figure.
 `,
-		Expected: `
+		Expected: `<p>Following image is without caption:</p>
 <img src="https://example.com/image.jpg" alt="Alt text">
+<p>So this won't be a figure.</p>
 `,
 	}, t)
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -41,6 +41,8 @@ func (b *figureParagraphTransformer) Transform(node *gast.Paragraph, reader text
 	// See CommonMark spec: https://spec.commonmark.org/0.30/#images.
 	if !imageRegexp.Match(firstLineStr) {
 		return
+	} else if lines.Len() == 1 {
+		return // Only image, no caption: skip
 	}
 	figure := fast.NewFigure()
 	node.Parent().ReplaceChild(node.Parent(), node, figure)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -39,10 +39,10 @@ func (b *figureParagraphTransformer) Transform(node *gast.Paragraph, reader text
 	// But this simple regex ignores image descriptions that contain other links.
 	// E.g. ![foo ![bar](/url)](/url2).
 	// See CommonMark spec: https://spec.commonmark.org/0.30/#images.
-	if !imageRegexp.Match(firstLineStr) {
+	var isImage = imageRegexp.Match(firstLineStr)
+	var onlyImage = isImage && lines.Len() == 1
+	if !isImage || onlyImage {
 		return
-	} else if lines.Len() == 1 {
-		return // Only image, no caption: skip
 	}
 	figure := fast.NewFigure()
 	node.Parent().ReplaceChild(node.Parent(), node, figure)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -20,17 +20,16 @@ import (
 var imageRegexp = regexp.MustCompile(`^!\[[^[\]]*\](\([^()]*\)|\[[^[\]]*\])\s*$`)
 
 type figureParagraphTransformer struct {
+	skipNoCaption bool
 }
-
-var defaultFigureParagraphTransformer = &figureParagraphTransformer{}
 
 // NewFigureParagraphTransformer returns a new ParagraphTransformer
 // that can transform paragraphs into figures.
-func NewFigureParagraphTransformer() parser.ParagraphTransformer {
-	return defaultFigureParagraphTransformer
+func NewFigureParagraphTransformer(skipNoCaption bool) parser.ParagraphTransformer {
+	return &figureParagraphTransformer{skipNoCaption: skipNoCaption}
 }
 
-func (b *figureParagraphTransformer) Transform(node *gast.Paragraph, reader text.Reader, pc parser.Context) {
+func (t *figureParagraphTransformer) Transform(node *gast.Paragraph, reader text.Reader, pc parser.Context) {
 	lines := node.Lines()
 	if lines.Len() < 1 {
 		return
@@ -40,8 +39,8 @@ func (b *figureParagraphTransformer) Transform(node *gast.Paragraph, reader text
 	var firstLineStr = firstSeg.Value(source)
 
 	var isImage = imageRegexp.Match(firstLineStr)
-	var onlyImage = isImage && lines.Len() == 1
-	if !isImage || onlyImage {
+	var hasNoCaption = isImage && lines.Len() == 1
+	if !isImage || (t.skipNoCaption && hasNoCaption) {
 		return
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -14,6 +14,9 @@ import (
 	"github.com/yuin/goldmark/text"
 )
 
+// This simple regex ignores image descriptions that contain other links.
+// E.g. ![foo ![bar](/url)](/url2).
+// See CommonMark spec: https://spec.commonmark.org/0.30/#images.
 var imageRegexp = regexp.MustCompile(`^!\[[^[\]]*\](\([^()]*\)|\[[^[\]]*\])\s*$`)
 
 type figureParagraphTransformer struct {
@@ -35,15 +38,13 @@ func (b *figureParagraphTransformer) Transform(node *gast.Paragraph, reader text
 	var source = reader.Source()
 	var firstSeg = lines.At(0)
 	var firstLineStr = firstSeg.Value(source)
-	// Here we simply match by regex.
-	// But this simple regex ignores image descriptions that contain other links.
-	// E.g. ![foo ![bar](/url)](/url2).
-	// See CommonMark spec: https://spec.commonmark.org/0.30/#images.
+
 	var isImage = imageRegexp.Match(firstLineStr)
 	var onlyImage = isImage && lines.Len() == 1
 	if !isImage || onlyImage {
 		return
 	}
+
 	figure := fast.NewFigure()
 	node.Parent().ReplaceChild(node.Parent(), node, figure)
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,9 +38,10 @@ func (t *figureParagraphTransformer) Transform(node *gast.Paragraph, reader text
 	var firstSeg = lines.At(0)
 	var firstLineStr = firstSeg.Value(source)
 
-	var isImage = imageRegexp.Match(firstLineStr)
-	var hasNoCaption = isImage && lines.Len() == 1
-	if !isImage || (t.skipNoCaption && hasNoCaption) {
+	if !imageRegexp.Match(firstLineStr) {
+		return
+	}
+	if t.skipNoCaption && lines.Len() == 1 {
 		return
 	}
 


### PR DESCRIPTION
Right now the library creates a `<figure>` element even when an image doesn't have caption.

For example this:

```md
Following image is without caption:

![Alt text](https://example.com/image.jpg)

So this won't be a figure.
```

Will be turned into this:

```html
<p>Following image is without caption:</p>
<figure><img src="https://example.com/image.jpg" alt="Alt text"></figure>
<p>So this won't be a figure.</p>
```

This is a problem in real life for websites like the "About" page of my blog:
1. [HTML](https://blog.bozso.dev/about)
2. [Markdown](https://gitlab.com/peterbozso/peterbozso.gitlab.io/-/blob/main/content/about.md?ref_type=heads&plain=1#L3)

As can be seen here, the image link is to my profile picture, standing on it's own, which I definitely don't want to turn into a `<figure>`.

This PR fixes this by not adding a `<figure>` element when there's no text right after the imagine in Markdown. Please refer to the newly addedd test to see it in action.
